### PR TITLE
Fix query parsing error

### DIFF
--- a/src/helpers/QueryParser.js
+++ b/src/helpers/QueryParser.js
@@ -94,7 +94,7 @@ export default class QueryParser {
     return {
       field: token.substring(0, matches[0].index).trim(),
       operator: token.substring(matches[0].index, operatorEndIndex),
-      value: token.substring(operatorEndIndex, token.length).replace(/[']+/g, ''),
+      value: token.substring(operatorEndIndex, token.length).replace(/[']+/g, '').trim(),
     };
   }
 

--- a/src/helpers/QueryParser.js
+++ b/src/helpers/QueryParser.js
@@ -92,7 +92,7 @@ export default class QueryParser {
     const mathesLength = matches.map(el => el.value).join('').length;
     const operatorEndIndex = matches[0].index + mathesLength;
     return {
-      field: token.substring(0, matches[0].index),
+      field: token.substring(0, matches[0].index).trim(),
       operator: token.substring(matches[0].index, operatorEndIndex),
       value: token.substring(operatorEndIndex, token.length).replace(/[']+/g, ''),
     };

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -41,9 +41,17 @@ describe('Query Parser', function () {
       const result = QueryParser.createTokenObject(token, operators);
       assert.equal(result.field, 'Firstname');
       assert.equal(result.operator, '=');
-      assert.equal(result.value, "'kek'");
+      assert.equal(result.value, "kek");
+    });
+    it('should return token object without extra space', function () {
+      const token = "Firstname IN 'kek, john'";
+      const result = QueryParser.createTokenObject(token, operators);
+      assert.equal(result.field, 'Firstname');
+      assert.equal(result.operator, 'IN');
+      assert.equal(result.value, "kek, john");
     });
   });
+
 
   describe('Get tokens array', function () {
     it('should return token array', function () {
@@ -52,12 +60,12 @@ describe('Query Parser', function () {
       const expectedResult = [
         '(',
         '(',
-        { field: 'Firstname', operator: '=', value: "'kek'" },
+        { field: 'Firstname', operator: '=', value: "kek" },
         'AND',
-        { field: 'Firstname', operator: '=', value: "'kek1'" },
+        { field: 'Firstname', operator: '=', value: "kek1" },
         ')',
         'OR',
-        { field: 'Firstname', operator: '=', value: "'kek3'" },
+        { field: 'Firstname', operator: '=', value: "kek3" },
         ')',
       ];
       assert.deepEqual(result, expectedResult);
@@ -71,7 +79,7 @@ describe('Query Parser', function () {
       const tree = ASTree.buildTree(tokens, combinators);
       const expectedResult = 'AND';
       const result = QueryParser.getFirstCombinator(tree, combinators);
-      assert.equal(result, expectedResult);
+      assert.equal(result.value, expectedResult);
     });
   });
 });


### PR DESCRIPTION
The field name and value contain extraneous space, which causes error when editing existing query in the UI.