### PR TITLE
Non-submit buttons 

### DIFF
--- a/src/Condition.js
+++ b/src/Condition.js
@@ -70,14 +70,15 @@ class Condition extends React.Component {
               return <option value={combinator.combinator} key={index}>{combinator.label}</option>;
             })}
         </select>
-        <button className={this.styles.primaryBtn} onClick={this.addCondition}>
+        <button type="button" className={this.styles.primaryBtn} onClick={this.addCondition}>
           {this.props.buttonsText.addGroup}
         </button>
-        <button className={this.styles.primaryBtn} onClick={this.addRule}>
+        <button type="button" className={this.styles.primaryBtn} onClick={this.addRule}>
           {this.props.buttonsText.addRule}
         </button>
         {this.props.nodeName !== '1'
           ? <button
+            type="button"
             onClick={() => this.handleDelete(this.props.nodeName)}
             className={this.styles.deleteBtn}>{this.props.buttonsText.delete}</button>
           : null}

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -151,6 +151,7 @@ class Rule extends React.Component {
         </select>
         {this.getInputTag(this.state.currField.input.type)}
         <button
+          type="button"
           className={this.styles.deleteBtn}
           onClick={this.handleDelete}
         >{this.props.buttonsText.delete}</button>


### PR DESCRIPTION
If I integrate this awesome package into a form like vazsco:uniforms, the buttons within it will act like submit buttons, which is not the desired behavior. As the buttons receive `type="submit"` by default, I changed this to have `type="button"`. Tested this and it works as desired.